### PR TITLE
Increase frequency of challenge interval to 60sec

### DIFF
--- a/app_mongo.js
+++ b/app_mongo.js
@@ -960,7 +960,7 @@ async function main() {
    
   interval = setInterval( forInterval, 2000);
   
-  setInterval(forIntervalChallenge, 3*60*1000); 
+  setInterval(forIntervalChallenge, 1*60*1000); // 60 sec
 
   return "Epicbox ready to work.";
 

--- a/app_mongo_many.js
+++ b/app_mongo_many.js
@@ -1314,7 +1314,7 @@ async function main() {
    
   interval = setInterval( forInterval, 2000);
   
-  setInterval(forIntervalChallenge, 3*60*1000); 
+  setInterval(forIntervalChallenge, 1*60*1000); // 60 sec
 
   return "Epicbox ready to work.";
 


### PR DESCRIPTION
This was prreviously set to 3 minutes. This is too slow for Cloudflare-protected, DNS-proxied subdomains, due to a hard-set timeout for WSS connections by Cloudflare.  

We either need to Ping once per timeout interval, or communicate with wallet listener in some way.

Our `Challenge` and "reply with signed `Challenge`" protocol messaging is effectively used as a ping... so modifying this resolves the `Closed with reason 1006` error on epicbox side.

Additionally, it resolves the `epic-wallet` listener errors printed to stdout.

Historically, any epicbox behind Cloudflare with DNS proxying enabled showed non-fatal `SocketClosed` errors.  These are now fixed on both sides of comms.